### PR TITLE
Fix styling for inline javascript

### DIFF
--- a/assets/cms/components/Icon.vue
+++ b/assets/cms/components/Icon.vue
@@ -1,11 +1,12 @@
 <template functional>
 
-    <i class="icon" :class="[{
-            'fas': props.iconType === 'fontawesome-solid',
-            'far': props.iconType === 'fontawesome-regular',
-            'fab': props.iconType === 'fontawesome-brand',
+    <i class="icon" 
+        :class="[{
+            fas: props.iconType === 'fontawesome-solid',
+            far: props.iconType === 'fontawesome-regular',
+            fab: props.iconType === 'fontawesome-brand',
         }, props.icon]"
-        :style="{ 'color': props.iconColor }"
+        :style="{ color: props.iconColor }"
     />
 
 </template>

--- a/assets/cms/components/IconButton.vue
+++ b/assets/cms/components/IconButton.vue
@@ -1,18 +1,18 @@
 <template functional>
     <button
         @click='listeners.click'
-        :class="[{
-                'btn btn-light' : props.format === 'floating',
-                'btn btn-outline-secondary' : props.format === 'outline',
-                'btn btn-outline-primary' : props.format === 'outline-primary',
-            }]"
+        :class="{
+            'btn btn-light': props.format === 'floating',
+            'btn btn-outline-secondary': props.format === 'outline',
+            'btn btn-outline-primary': props.format === 'outline-primary',
+        }"
         :disabled="props.disabled"
         >
         <span class="label" v-if="props.labelPosition === 'left'">
             <slot />
         </span>
 
-        <Icon :icon="props.icon" :icon-type="props.iconType" :icon-color="props.iconColor"/>
+        <Icon :icon="props.icon" :icon-type="props.iconType" :icon-color="props.iconColor" />
 
         <span class="label" v-if="props.labelPosition === 'right'">
             <slot />


### PR DESCRIPTION
We use standardjs with 4 space indentation, you can try these out and see that these are correct here: https://standardjs.com/demo.html

Of course our tooling should be validating this and holding you to it but for some reason eslint isn't applying to vue properties, I'll have to see about that later.